### PR TITLE
Compatibility with latest Puppet version (v3.1.0)

### DIFF
--- a/lib/puppet/parser/functions/trocla_set.rb
+++ b/lib/puppet/parser/functions/trocla_set.rb
@@ -50,9 +50,7 @@ trocla, for example via cli.
     configfile = File.join(File.dirname(Puppet.settings[:config]), "troclarc.yaml")
   
     raise(Puppet::ParseError, "Trocla config file #{configfile} not readable") unless File.exist?(configfile)
-    raise(Puppet::ParseError, "You need rubygems to use Trocla") unless Puppet.features.rubygems?
-  
-    require 'rubygems'
+
     require 'trocla'
   
     result = (trocla=Trocla.new(configfile)).set_password(key,format,value)

--- a/lib/puppet/util/trocla_helper.rb
+++ b/lib/puppet/util/trocla_helper.rb
@@ -25,9 +25,7 @@ module Puppet::Util::TroclaHelper
         configfile = File.join(File.dirname(Puppet.settings[:config]), "troclarc.yaml")
 
         raise(Puppet::ParseError, "Trocla config file #{configfile} is not readable") unless File.exist?(configfile)
-        raise(Puppet::ParseError, "You need rubygems to use Trocla") unless Puppet.features.rubygems?
 
-        require 'rubygems'
         require 'trocla'
         
         has_options ? Trocla.new(configfile).send(trocla_func, key, format, options) : Trocla.new(configfile).send(trocla_func, key, format)


### PR DESCRIPTION
This makes the Gem usable in the latest Puppet versions.

The handling of RubyGems got revised in Puppet 3.0.1-rc1:
  http://projects.puppetlabs.com/issues/16757

The new policy is that either bundler and/or rubygems are guaranteed to
be loaded and initialized when the Puppet manifest is evaluated, making
it unnecessary for Puppet modules to load rubygems.

This new policy broke the puppet-trocla module. This is because
'Puppet.features.rubygems?' always evaluates to false now, which causes
the module to abort the manifest compilation with a message informing
about the necessity of RubyGems to be present.
