### PR TITLE
Add custom hiera backend for trocla

### DIFF
--- a/lib/hiera/backend/trocla_backend.rb
+++ b/lib/hiera/backend/trocla_backend.rb
@@ -1,0 +1,114 @@
+# Custom hiera backend for trocla
+#
+# Only reacts to key namespace trocla::password::<trocla_key>. Looks up
+# additional parameters via hiera itself as
+# trocla::options::<trocla_key>::format (string) and
+# trocla::options::<trocla_key>::options (hash). Looks for <trocla_key> in
+# trocla as hiera/<source>/<trocla> with <source> iterating over the configured
+# hiera hierarchy. If not found, creates and returns a new password with trocla
+# key <trocla_key>.
+#
+# example entry in hiera.yaml:
+# backends:
+#   - ...
+#   - trocla
+# trocla:
+#   - configfile: /etc/puppet/troclarc.yaml
+#   - format: plain
+#   - options:
+#     length: 16
+#
+# example usage in hiera yaml file:
+# kerberos::kdc_database_password: "%{hiera('trocla::password::kdc_database_password')}"
+# trocla::options::kdc_database_password::format: 'plain'
+# trocla::options::kdc_database_password::options:
+#   length: 71
+class Hiera
+  module Backend
+    class Trocla_backend
+
+      def initialize
+        @trocla = nil
+
+        Hiera.debug("Hiera Trocla backend starting")
+        require 'trocla'
+
+        default_configfile = "/etc/puppet/troclarc.yaml"
+        default_default_format = "plain"
+        default_default_options = {}
+
+        begin
+          configfile = Config[:trocla][:configfile] || default_configfile
+        rescue
+          configfile = default_configfile
+        end
+
+        if not File.exist?(configfile)
+          Hiera.warn("Trocla config file #{configfile} is not readable")
+          return
+        end
+
+        begin
+          @default_format = Config[:trocla][:format] || default_default_format
+        rescue
+          @default_format = default_default_format
+        end
+
+        begin
+          @default_options = Config[:trocla][:options] || default_default_options
+        rescue
+          @default_options = default_default_options
+        end
+
+        @trocla = Trocla.new(configfile)
+      end
+
+      def lookup(key, scope, order_override, resolution_type)
+        return nil unless @trocla
+
+        Hiera.debug("Looking up #{key} in trocla backend")
+
+        password_namespace = 'trocla::password::'
+        options_namespace = 'trocla::options::'
+
+        # we only accept trocla::password:: lookups because we do hiera lookups
+        # ourselves and could otherwise cause loops
+        return nil unless key.start_with?(password_namespace)
+
+        # cut off trocla hiera namespace: trocla::password::root -> root
+        trocla_key = key[password_namespace.length,
+                         key.length - password_namespace.length]
+        Hiera.debug("Looking for key #{trocla_key} in trocla")
+
+        # HERE BE DRAGONS: hiera lookups from backend to determine additional
+        # trocla options for this password
+        format = Backend.lookup(options_namespace + trocla_key + '::format',
+                                @default_format, scope, nil, :priority)
+
+        answer = nil
+        # Go looking for existing password as hiera/<source>/<trocla_key>.
+        # Would need to be initialised externally, e.g by calling
+        # trocla('hiera/osfamily/Debian/jessie/root' in site.pp.  Alternatively
+        # we could use hiera's concept of datafiles to look into different
+        # trocla password stores. But this would need somehow providing
+        # different troclarcs as well.
+        sources = Backend.datasources(scope, order_override) do |source|
+          Hiera.debug("Looking for data source #{source}")
+          break if answer = @trocla.send(:get_password,
+                                         'hiera/' + source + '/' + trocla_key,
+                                         format)
+        end
+
+        if not answer
+          # create a new password
+          options = Backend.lookup(options_namespace + trocla_key + '::options',
+                                   @default_options, scope, nil, :hash)
+          answer = @trocla.send(:password, trocla_key, format, options)
+        end
+
+        return answer
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
I wrote a custom hiera backend for trocla. Would you be interested in it?

I made some design decisions open for discussion:
- To get additional parameters for the trocla function on a per-password basis, the lookup function of the custom backend does itself do hiera lookups.
- To prevent loops, the backend only reacts to namespace trocla::password:: and does all additional lookups into trocla::options::

This means that password creation has to be triggered via explicit hiera function interpolation lookups such as:

```kerberos::kdc_database_password: "%{hiera('trocla::password::kdc_database_password')}"```

I looked into just adding a `"%{trocla('<key>')}"` function but there's no API for that and the existing functions `hiera` and `scope` are pretty hard-coded in the hiera source. Getting trocla-support in there without adding a whole extension function API is unlikely.

- It implements the actual hiera hierarchy by pre-pending the hiera path to the trocla key as `hiera/<source>/<trocla_key>`. This way, the same trocla key could yield different passwords for different groups of machines. I'm not sure, how much use this would actually be in practice. Also, that key would need to be initialised externally, e.g by calling `trocla('hiera/osfamily/Debian/jessie/root'` in site.pp. Alternatively we could use hiera's concept of datafiles to look into different trocla password stores. But this would need somehow providing different troclarcs as well.

Only reacts to key namespace trocla::password::<trocla_key>. Looks up
additional parameters via hiera itself as
`trocla::options::<trocla_key>::format` (string) and
`trocla::options::<trocla_key>::options` (hash). Looks for `<trocla_key>` in
trocla as `hiera/<source>/<trocla>` with `<source>` iterating over the
configured hiera hierarchy. If not found, creates and returns a new
password with trocla key `<trocla_key>`.

example entry in hiera.yaml:
```
backends:
  - ...
  - trocla
trocla:
  - configfile: /etc/puppet/troclarc.yaml
  - format: plain
  - options:
    length: 16
```

example usage in hiera yaml file:
```
kerberos::kdc_database_password: "%{hiera('trocla::password::kdc_database_password')}"
trocla::options::kdc_database_password::format: 'plain'
trocla::options::kdc_database_password::options:
  length: '71'
```