### PR TITLE
Support for puppetserver

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -14,7 +14,7 @@ class trocla::master (
       provider => $provider,
     }
   }
-  if $provider != 'gem' and $::osfamily == 'RedHat' {
+  if $provider != 'gem' and $provider != 'puppetserver_gem' and $::osfamily == 'RedHat' {
     Package['trocla']{
       name => 'rubygem-trocla'
     }


### PR DESCRIPTION
Hi,

This patch allow to use puppetserver_gem to deploy trocla on a puppetserver instance.

Dependencies : https://github.com/puppetlabs/puppetlabs-puppetserver_gem

Best regards,