### PR TITLE
fix template yaml indentation

### DIFF
--- a/spec/classes/yaml_spec.rb
+++ b/spec/classes/yaml_spec.rb
@@ -20,7 +20,7 @@ describe 'trocla::yaml', :type => 'class' do
 profiles:
   sysdomain_nc:
     name_constraints:
-    - example.com
+      - example.com
 store: :moneta
 store_options:
   adapter: :YAML

--- a/templates/troclarc.yaml.erb
+++ b/templates/troclarc.yaml.erb
@@ -11,7 +11,7 @@
         out << "#{indent}#{e[0]}:"
         out << sort_pseudo_yaml(e[1],indent+'  ')
       elsif e[1].is_a?(Array)
-        out << (["#{indent}#{e[0]}:"]+e[1].collect{|e| "- #{e}" }).join("\n#{indent}")
+        out << (["#{indent}#{e[0]}:"]+e[1].collect{|e| "  - #{e}" }).join("\n#{indent}")
       else
         out << "#{indent}#{e[0].is_a?(Symbol) ? ":#{e[0].to_s}" : e[0]}: #{e[1].is_a?(Symbol) ? ":#{e[1].to_s}" : e[1]}"
       end


### PR DESCRIPTION
The indentation for arrays (sequences) seems to be broken in the template file.
This PR fixes the indentation bug in the yaml template.