### PR TITLE
fix argument order in trocla_set

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,19 @@ Usage:
 
 This will set the passed password for the key/format pair and return it
 as well. This is mainly interesting if you want to migrate existing manifests
-with plenty of passwords in it to trocla.
+with plenty of passwords in it to trocla. 
+
+Note that the `FORMAT`, in this context, is the format of the
+`PASSWORD` itself: it will not reencode it unless you pass a second
+argument, for example:
+
+    trocla_set('admin', 'test', 'plain')
+
+... will return the string "test" but this:
+
+    trocla_set('admin', 'test', 'plain', 'bcrypt')
+
+... will return a bcrypt-hashed password.
 
 ## Hiera backend
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ existing in trocla's database.
 
 Usage:
 
-    trocla_set(KEY, FORMAT,PASSWORD)
+    trocla_set(KEY, PASSWORD, FORMAT)
 
 This will set the passed password for the key/format pair and return it
 as well. This is mainly interesting if you want to migrate existing manifests


### PR DESCRIPTION
The code (and its inline documentation) does explicitely state the
password is the second argument, and not format. I assume this is just
a typo.