### PR TITLE
Fix lint issues, making the module compatible with puppet 8

### DIFF
--- a/manifests/ca/params.pp
+++ b/manifests/ca/params.pp
@@ -4,7 +4,7 @@
 class trocla::ca::params(
   $trocla_options = {
     'profiles' => ['sysdomain_nc','x509veryverylong'],
-    'CN'       => "automated-ca ${name} for ${::domain}",
+    'CN'       => "automated-ca ${name} for ${facts['networking']['domain']}",
   },
 ) {
   $ca_options = merge($trocla_options,{ become_ca => true, render => { certonly => true }})

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@
 class trocla::config (
   $options                         = {},
   $profiles                        = {},
-  $x509_profile_domain_constraints = [$::domain],
+  $x509_profile_domain_constraints = [$facts['networking']['domain']],
   $store                           = undef,
   $store_options                   = {},
   $encryption                      = undef,

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -6,7 +6,7 @@ class trocla::master (
   $provider = 'default',
 ) {
   package {'trocla':
-    ensure   => 'installed',
+    ensure => 'installed',
   }
 
   if $provider != 'default' {
@@ -14,7 +14,7 @@ class trocla::master (
       provider => $provider,
     }
   }
-  if $provider != 'gem' and $provider != 'puppetserver_gem' and $::osfamily == 'RedHat' {
+  if $provider != 'gem' and $provider != 'puppetserver_gem' and $facts['os']['family'] == 'RedHat' {
     Package['trocla']{
       name => 'rubygem-trocla'
     }


### PR DESCRIPTION
puppet 8 disables legacy facts by default, so this module does not work correctly unless legacy facts are re-enabled.

Closes: #30